### PR TITLE
add support for puppetlabs-iis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2017-09-04 Release 0.0.6
+- Support puppetlabs/iis puppet module
+
 2016-10-11 Release 0.0.5
 - Allow either chocolatey/chocolatey or puppetlabs/chocolatey [#11](https://github.com/chocolatey/puppet-chocolatey_server/issues/11)
 - Support Windows 2008 [#7](https://github.com/chocolatey/puppet-chocolatey_server/issues/7)

--- a/Rakefile
+++ b/Rakefile
@@ -38,8 +38,21 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-task :metadata do
+task :metadata_lint do
   sh "metadata-json-lint metadata.json"
+end
+
+desc "Custom: Download third-party modules"
+task :r10k do
+  system 'r10k puppetfile install -v'
+end
+
+desc "Custom: Prepare symbolic link to root puppet module folders"
+task :symlink do
+  FileUtils.remove_dir("development/modules/chocolatey_server",:verbose => true)
+  FileUtils.mkdir_p "development/modules/chocolatey_server"
+  FileUtils.cd "development/modules/chocolatey_server"
+  system 'ln -s "../../../manifests" "manifests"'
 end
 
 desc "Run syntax, lint, and spec tests."
@@ -47,5 +60,9 @@ task :test => [
   :syntax,
   :lint,
   :spec,
-  :metadata,
+  :metadata_lint,
+  :r10k,
+  :symlink
 ]
+
+task :default => [:test]

--- a/metadata.json
+++ b/metadata.json
@@ -40,8 +40,8 @@
       "version_requirement": ">= 1.0.4 < 3.0.0"
     },
     {
-      "name": "puppet/iis",
-      "version_requirement": ">= 1.3.0 < 2.0.0"
+      "name": "puppetlabs/iis",
+      "version_requirement": ">= 4.0.0 < 4.2.0"
     },
     {
       "name": "puppet/windowsfeature",


### PR DESCRIPTION
* added support for puppetlabs-iis dependency however it needs to be on version `4.1.0`. 
* included runtime dependencies for vagrant.
* using a personal vagrant `windows2012r2` with chocolatey from `packer-windows` project.
* puppet version `4.8.2`.